### PR TITLE
feat: contenarize app with Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM --platform=linux/amd64 node:19.9-alpine as build
-EXPOSE 3000
-WORKDIR /app
-RUN rm -rf node_modules
-COPY . /app
-RUN npm ci
-CMD ["npm", "start"]
+FROM node:18-alpine
+
+WORKDIR /project
+
+COPY . .
+
+RUN npm install
+
+EXPOSE 4321
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=linux/amd64 node:19.9-alpine as build
 EXPOSE 3000
 WORKDIR /app
+RUN rm -rf node_modules
 COPY . /app
+RUN npm ci
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM --platform=linux/amd64 node:19.9-alpine as build
+EXPOSE 3000
+WORKDIR /app
+COPY . /app
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ All commands are run from the root of the project, from a terminal:
 | `npm run preview`         | Preview your build locally, before deploying     |
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
+
+### 🐳 Docker Commands
+
+All Docker commands are run from the root of the project, from a terminal:
+
+| Command                               | Action                                                   |
+| :------------------------------------ | :------------------------------------------------------- |
+| `docker build -t app:1.0.0 .`         | Build the Docker image for the Astro application.        |
+| `docker run -p 80:4321 app:1.0.0`     | Run a Docker container with the built Astro application. |
+| `docker pull edwardb11/app:2.0.0`     | Download the Docker image from Docker Hub.               |


### PR DESCRIPTION
### Description

This Pull Request introduces changes to the Dockerfile and configuration to optimize the Docker image for the Astro application.

### Proposed Changes

- Optimizations have been made to the Dockerfile to reduce the image size.
- Dockerize application

### Note: 
**You need to have [Docker](https://www.docker.com/get-started/) on your machine**


### Steps to Test the Docker Image

1. **Build the Image:**

   Open a terminal and navigate to the project directory containing your Dockerfile.

   ```bash
   docker build -t app:1.0.0 .

2. **Run a Container with the Image:**

   ```bash
    docker run -p 80:4321 --name tailwind-astro-starting-blog app:1.0.0

3. **Access the Application:**
   ```bash
   Open your browser and navigate to http://localhost:80/. Verify that the Astro application is functioning correctly.

### Docker Hub Public with the image:

   ```bash
   docker pull edwardb11/app:2.0.0

   docker run -p 80:4321 --name tailwind-astro-starting-blog edwardb11/app:2.0.0
